### PR TITLE
add_effect refactor

### DIFF
--- a/native/lambda_game_engine/src/myrra_engine/game.rs
+++ b/native/lambda_game_engine/src/myrra_engine/game.rs
@@ -813,10 +813,10 @@ impl GameState {
                     ap.modify_health(-attack_dmg);
 
                     match extra_effect {
-                        Some((effect, false, effect_data)) => {
+                        Some((effect, effect_data)) => {
                             let mut effect_data = effect_data.clone();
                             effect_data.caused_to = ap.id;
-                            ap.add_effect(effect, effect_data);
+                            ap.add_effect(effect, false, effect_data);
                         }
                         None => (),
                     }

--- a/native/lambda_game_engine/src/myrra_engine/game.rs
+++ b/native/lambda_game_engine/src/myrra_engine/game.rs
@@ -419,6 +419,7 @@ impl GameState {
                         GameState::get_player_mut(&mut self.players, attacked_player_id)?;
                     attacked_player.add_effect(
                         Effect::ElnarMark,
+                        true,
                         EffectData {
                             time_left: attacking_player.character.duration_basic_skill(),
                             ends_at: add_millis(
@@ -433,7 +434,7 @@ impl GameState {
                             caused_to: attacked_player.id,
                             damage: 0,
                         },
-                    )
+                    );
                 }
                 Ok(attacked_players_ids)
             }
@@ -591,7 +592,7 @@ impl GameState {
                     Some((effect, effect_data)) => {
                         let mut effect_data = effect_data.clone();
                         effect_data.caused_to = attacked_player.id;
-                        attacked_player.add_effect(effect, effect_data);
+                        attacked_player.add_effect(effect, false, effect_data);
                     }
                     None => (),
                 }
@@ -618,6 +619,7 @@ impl GameState {
                 let now = time_now();
                 attacking_player.add_effect(
                     Effect::Scherzo.clone(),
+                    false,
                     EffectData {
                         time_left: attacking_player.character.duration_basic_skill(),
                         ends_at: add_millis(now, attacking_player.character.duration_basic_skill()),
@@ -691,6 +693,7 @@ impl GameState {
 
                         attacked_player.add_effect(
                             Effect::YugenMark,
+                            false,
                             EffectData {
                                 time_left: duration,
                                 ends_at: add_millis(now, duration),
@@ -705,6 +708,7 @@ impl GameState {
                         );
                         attacked_player.add_effect(
                             Effect::Poisoned,
+                            false,
                             EffectData {
                                 time_left: duration,
                                 ends_at: add_millis(now, duration),
@@ -809,7 +813,7 @@ impl GameState {
                     ap.modify_health(-attack_dmg);
 
                     match extra_effect {
-                        Some((effect, effect_data)) => {
+                        Some((effect, false, effect_data)) => {
                             let mut effect_data = effect_data.clone();
                             effect_data.caused_to = ap.id;
                             ap.add_effect(effect, effect_data);
@@ -850,6 +854,7 @@ impl GameState {
 
             attacked_player.add_effect(
                 Effect::DanseMacabre.clone(),
+                false,
                 EffectData {
                     time_left: duration,
                     ends_at: add_millis(now, duration),
@@ -910,6 +915,7 @@ impl GameState {
                     Some((player_id, _position)) => {
                         attacking_player.add_effect(
                             Effect::XandaMarkOwner,
+                            false,
                             EffectData {
                                 time_left: duration,
                                 ends_at: add_millis(now, duration),
@@ -927,6 +933,7 @@ impl GameState {
                             GameState::get_player_mut(&mut self.players, player_id)?;
                         attacked_player.add_effect(
                             Effect::XandaMark,
+                            false,
                             EffectData {
                                 time_left: duration,
                                 ends_at: add_millis(now, duration),
@@ -1008,6 +1015,7 @@ impl GameState {
             Name::H4ck => {
                 attacking_player.add_effect(
                     Effect::NeonCrashing,
+                    false,
                     EffectData {
                         time_left: attacking_player.character.duration_skill_3(),
                         ends_at: add_millis(now, attacking_player.character.duration_skill_3()),
@@ -1036,6 +1044,7 @@ impl GameState {
                 attacking_player.action = PlayerAction::STARTINGSKILL3;
                 attacking_player.add_effect(
                     Effect::Leaping,
+                    false,
                     EffectData {
                         time_left: MillisTime {
                             high: 0,
@@ -1074,6 +1083,7 @@ impl GameState {
         let now = time_now();
         attacking_player.add_effect(
             Effect::Raged,
+            false,
             EffectData {
                 time_left: attacking_player.character.duration_skill_2(),
                 ends_at: add_millis(now, attacking_player.character.duration_skill_2()),
@@ -1111,6 +1121,7 @@ impl GameState {
             Name::H4ck => {
                 attacking_player.add_effect(
                     Effect::DenialOfService,
+                    false,
                     EffectData {
                         time_left: attacking_player.character.duration_skill_4(),
                         ends_at: add_millis(now, attacking_player.character.duration_skill_4()),
@@ -1144,6 +1155,7 @@ impl GameState {
             Name::Muflus => {
                 attacking_player.add_effect(
                     Effect::FieryRampage,
+                    false,
                     EffectData {
                         time_left: attacking_player.character.duration_skill_4(),
                         ends_at: add_millis(now, attacking_player.character.duration_skill_4()),
@@ -1201,6 +1213,8 @@ impl GameState {
     pub fn world_tick(self: &mut Self, out_of_area_damage: i64) -> Result<(), String> {
         let now = time_now();
         let pys = self.players.clone();
+
+        // Status effects
         let mut neon_crash_affected_players: HashMap<
             u64,
             (Vec<(u64, i64)>, Option<(Effect, MillisTime)>),
@@ -1374,6 +1388,7 @@ impl GameState {
                         ProjectileType::DISARMINGBULLET => {
                             attacked_player.add_effect(
                                 Effect::Paralyzed,
+                                false,
                                 EffectData {
                                     time_left: MillisTime { high: 0, low: 5000 },
                                     ends_at: add_millis(now, MillisTime { high: 0, low: 5000 }),
@@ -1504,7 +1519,7 @@ impl GameState {
                                     caused_to: ap.id,
                                     damage: 0,
                                 };
-                                ap.add_effect(effect.clone(), effect_data.clone());
+                                ap.add_effect(effect.clone(), false, effect_data.clone());
                             }
                             None => {}
                         }

--- a/native/lambda_game_engine/src/myrra_engine/player.rs
+++ b/native/lambda_game_engine/src/myrra_engine/player.rs
@@ -282,19 +282,34 @@ impl Player {
     }
 
     #[inline]
-    pub fn add_effect(&mut self, e: Effect, ed: EffectData) {
-        if !self.effects.contains_key(&e) {
+    pub fn add_effect(&mut self, effect: Effect, reset_countdown: bool, effect_data: EffectData) {
+        if !self.effects.contains_key(&effect) {
             match self.character.name {
                 Name::Muflus => {
-                    if !(self.muflus_partial_immunity(&e)) {
-                        self.effects.insert(e, ed);
+                    if !(self.muflus_partial_immunity(&effect)) {
+                        self.effects.insert(effect, effect_data);
                     }
                 }
                 _ => {
-                    self.effects.insert(e, ed);
+                    self.effects.insert(effect, effect_data);
                 }
             }
         }
+        // Only resets effect countdown if both effects were caused by the same attacking player
+        // TODO: reset_countdown should probably be another field in the EffectData struct
+        // TODO: add field "non_unique": if different sources apply the same effect on the target, target should receive multiple instances of the same effect.
+        else if reset_countdown == true {
+            let current_effect = self.effects.get(&effect);
+            match current_effect {
+                Some(current_effect) => {
+                    if current_effect.caused_by == effect_data.caused_by {
+                        self.effects.insert(effect, effect_data); // resets countdown
+                    }
+                }
+                None => return (),
+            }
+        }
+        println!("{:?}", self.effects);
     }
 
     #[inline]
@@ -402,7 +417,7 @@ impl Player {
             + self.has_mark(&Effect::XandaMark, attacking_player_id)
     }
 
-    fn has_mark(self: &Self, e: &Effect, attacking_player_id: u64) -> u64 {
+    pub fn has_mark(self: &Self, e: &Effect, attacking_player_id: u64) -> u64 {
         let mark = self.effects.get(e);
         return if matches!(
             mark,


### PR DESCRIPTION
This PR is a part of https://github.com/lambdaclass/curse_of_myrra/issues/802
Only resets effect countdown if both effects were caused by the same attacking player