### PR TITLE
Fix Uma marks bug

### DIFF
--- a/native/lambda_game_engine/src/myrra_engine/game.rs
+++ b/native/lambda_game_engine/src/myrra_engine/game.rs
@@ -1,7 +1,7 @@
 use super::board::Board;
 use super::character::{Character, Name};
 use super::loot::{self, Loot, LootType};
-use super::player::{self, Effect, EffectData, Player, PlayerAction, Position, Status};
+use super::player::{Effect, EffectData, Player, PlayerAction, Position, Status};
 use super::projectile::{Projectile, ProjectileStatus, ProjectileType};
 use super::skills::{self, Skill};
 use super::time_utils::{
@@ -1509,11 +1509,17 @@ impl GameState {
             };
 
             let time_between_hits = (1000 / 2) as u32;
+
+            // Damage is evenly distributed between the duration of the effect
             let damage = effect_data.damage / (effect_data.duration.low as u32 / time_between_hits);
 
             if millis_to_u128(sub_millis(now, effect_data.triggered_at)) > time_between_hits as u128
             {
-                player.modify_health(-(damage as i64));
+                if effect == Effect::Poisoned && player.has_active_effect(&Effect::YugenMark) {
+                    player.modify_health_without_killing(-(damage as i64));
+                } else {
+                    player.modify_health(-(damage as i64));
+                }
                 effect_data.triggered_at = now;
             }
             poisoned_affected_players
@@ -1597,12 +1603,11 @@ impl GameState {
         self: &mut Self,
         affected_players: HashMap<u64, (i64, u64)>,
     ) -> Result<(), String> {
-        for (player_id, (damage, attacked_player_id)) in affected_players.iter() {
+        for (_player_id, (damage, attacked_player_id)) in affected_players.iter() {
             let attacked_player =
                 GameState::get_player_mut(&mut self.players, *attacked_player_id)?;
             if !matches!(attacked_player.status, Status::DEAD) {
-                attacked_player.modify_health(-damage);
-                self.update_killfeed(*player_id, vec![*attacked_player_id]);
+                attacked_player.modify_health_without_killing(-damage);
             }
         }
 


### PR DESCRIPTION
This PR fixes the bug due to which, if a character had Yugen's and/or Xanda's marks applied, no damage greater than its current health was received. This meant that not only Yugen's and Xanda's mark couldn't kill the character (which is correct), but any other form of attack couldn't either (which was the bug).